### PR TITLE
Use mutation observers for YouTube and Twitch

### DIFF
--- a/DGG_Chat_For_Youtube/popup.html
+++ b/DGG_Chat_For_Youtube/popup.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
-    <script src="js/jquery/jquery.min.js"></script>
+    <script type="text/javascript" src="js/jquery/jquery.min.js"></script>
 </head>
 
 <body>

--- a/DGG_Chat_For_Youtube/src/background.js
+++ b/DGG_Chat_For_Youtube/src/background.js
@@ -1,8 +1,23 @@
-chrome.tabs.query({currentWindow: true, active: true}, function(tabs){
-    currentUrl = tabs[0].url;
-    chrome.runtime.onMessage.addListener(
-        function(request, sender, sendResponse) {
-            sendResponse({currentUrl: sender.tab.url});
-        }
-      );
-});
+// for future use of multiple chat sources in the future
+
+// async function activeTab(activeInfo) {
+//     chrome.tabs.query({'active':true,'currentWindow':true}, async function(array_of_tabs){
+//         if (array_of_tabs[0].url.indexOf('youtube.com/watch') > -1) {
+//             // message the content script to update the src
+//             await chrome.tabs.sendMessage(array_of_tabs[0].id, {message: "updateSrc"}, async function(response) {
+//                 let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+//                 if(chrome.runtime.lastError || !response) {
+//                     console.log('script is not injected yet')
+//                     chrome.scripting.executeScript({
+//                         target: {tabId: tab.id, allFrames: true},
+//                         files: ['src/content.js'],
+//                     });
+//                 } else if (response){
+//                     console.log(response.message);
+//                 }
+//             });
+//         }
+//     });
+// }
+
+// chrome.tabs.onActivated.addListener(activeTab)

--- a/DGG_Chat_For_Youtube/src/content.js
+++ b/DGG_Chat_For_Youtube/src/content.js
@@ -4,67 +4,133 @@ function isDGGLoaded() {
 }
 
 function loadDGGTW() {
-    chrome.storage.sync.get("checkbox", function(result) {
-        if (result.checkbox == true && isDGGLoaded() == false) {
-            twitch_chat = $(`div[class*=channel-root__right-column]`);
-            console.log(
-                '%c[DGG] %cPEEPO POOFING TWITCH CHAT AWAY',
-                'color: #538CC6',
-                'color: #6F859A',
-            );
-            twitch_chat.empty();
-            // console.log("POOF")
-            url = "https://www.destiny.gg/embed/chat"
-            twitch_chat.prepend(`<div style="display:block; height: 100% !important; width: 100% !important;"><iframe id="chatframe" class="dggChat" style="height: 100% !important; width: 100% !important; display: block;" src="${url}"></iframe></div>`)
-        }
-    });
+    twitch_chat = $(`div[class*=channel-root__right-column]`);
+
+    console.log(
+        '%c[DGG] %cPEEPO POOFING TWITCH CHAT AWAY',
+        'color: #538CC6',
+        'color: #6F859A',
+    );
+    twitch_chat.empty();
+    // console.log("POOF")
+    url = "https://www.destiny.gg/embed/chat"
+    twitch_chat.prepend(`<div style="display:block; height: 100% !important; width: 100% !important;"><iframe id="chatframe" class="dggChat" style="height: 100% !important; width: 100% !important; display: block;" src="${url}"></iframe></div>`)
 }
 
 function loadDGGYT() {
-    chrome.storage.sync.get("checkbox", function(result) {
-        if (result.checkbox == true && isDGGLoaded() == false) {
-            dggChat = $("ytd-live-chat-frame")
-            console.log(
-                '%c[DGG] %cPEEPO POOFING YOUTUBE CHAT AWAY',
-                'color: #538CC6',
-                'color: #6F859A',
-            );
-            dggChat.empty()
-            dggChat.css({
-                "flex-direction": "row",
-                "-webkit-flex-direction": "row",
-            });
-            url = "https://www.destiny.gg/embed/chat"
-            dggChat.prepend(`<iframe id="chatframe" class="dggChat" style="flex: auto;" src="${url}"></iframe>`)
-        }
+    dggChat = $("ytd-live-chat-frame")
+    console.log(
+        '%c[DGG] %cPEEPO POOFING YOUTUBE CHAT AWAY',
+        'color: #538CC6',
+        'color: #6F859A',
+    );
+    dggChat.empty()
+    dggChat.css({
+        "flex-direction": "row",
+        "-webkit-flex-direction": "row",
     });
-};
+    url = "https://www.destiny.gg/embed/chat"
+    dggChat.prepend(`<iframe id="chatframe" class="dggChat" style="flex: auto;" src="${url}"></iframe>`)
+}
 
-document.onreadystatechange = function() {
-    if (document.readyState === 'complete') {
-
-        try {
-            if (window.location.href.indexOf('youtube.com') > -1) {
-                ObserverYT = new MutationObserver((mutationList, ObserverYT) => {
-                    if ($("ytd-live-chat-frame").length && $("#chatframe").length) {
-                        loadDGGYT()
-                        ObserverYT.disconnect();
-                    }}
-                );
-                ObserverYT.observe($('ytd-app')[0], {childList: true, subtree: true});
-            } else if (window.location.href.indexOf('twitch.tv') > -1) {
-
-                observerTW = new MutationObserver((mutationList, observer) => {
-                    if ($(`div[class*=channel-root__right-column]`).length) {
-                        loadDGGTW();
-                        observerTW.disconnect();
-                    }}
-                );
-                // this works for the most part but can have funky AdBlock behavior, not sure why yet
-                observerTW.observe($(`div[class*=channel-root__right-column]`)[0], {childList: true, subtree: true});
-            }
-        } catch (e) {
-            console.log(e);
-        }
+function updateYoutubeSrc() {
+    if (window.location.href.indexOf('youtube.com/watch') > -1) {
+        // save youtube url to storage for the popup 
+        chrome.storage.sync.set({"youtubeChatSrc": "https://www.youtube.com/live_chat?v=" + window.location.href.substring(window.location.href.lastIndexOf('=') + 1)})
     }
 }
+
+function CHAT_REPLACER_9000() {
+    // that one function im too lazy to split up
+
+    // try catch for some GET errors from the twitch api
+    try {
+        if (window.location.href.indexOf('youtube.com/watch') > -1) {
+            console.log("CONTENT YOUTUBE")
+            // save youtube url to storage for the popup if it is not the dgg chat
+            updateYoutubeSrc()
+
+            // test to see if the src is saved
+            chrome.storage.sync.get("youtubeChatSrc", function(result) {
+                console.log("YOUTUBE = ", result.youtubeChatSrc)
+            });
+            
+            chrome.storage.sync.get("checkbox", function(result) {
+                if (result.checkbox == true && isDGGLoaded() == false) {
+
+                    const intervalId = setInterval(() => {
+                        if ($('ytd-live-chat-frame').length && $('#chatframe').length) {
+
+                            loadDGGYT();
+                            if ($(`iframe[class*=dggChat]`).length){
+                                clearInterval(intervalId);
+                            }
+                        }
+                    }, 500);
+            }});
+        } 
+        else if (window.location.href.indexOf('twitch.tv') > -1) {
+
+            // if the checkbox is not checked append the proper chat to the page
+            twitchChatSrc = `https://www.twitch.tv/popout/${
+                window.location.href.substring(
+                    window.location.href.lastIndexOf('/') + 1
+                    )
+                }/chat?popout=`
+            
+                console.log("CONTENT TWITCH")
+
+            // save twitch url to storage for the popup
+            chrome.storage.sync.set({"twitchChatSrc": twitchChatSrc})
+            
+            chrome.storage.sync.get("twitchChatSrc", function(result) {
+                console.log("TWITCH = ", result.twitchChatSrc)
+            });
+            chrome.storage.sync.get("checkbox", function(result) {
+                if (result.checkbox == true && isDGGLoaded() == false) {
+                    const intervalId = setInterval(() => {
+                        if ($(`div[class*=channel-root__right-column]`)) {
+                            console.log("TRYING")
+                            loadDGGTW();
+                            if ($(`iframe[class*=dggChat]`).length){
+                                console.log("LOADED")
+                                clearInterval(intervalId);
+                            }
+                        }
+                    }, 500);
+                }
+            });
+        }
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+// run the function on page load
+document.addEventListener('DOMContentLoaded', function() {
+    CHAT_REPLACER_9000();
+});
+
+let lastUrl = location.href; 
+// run the function on url change
+new MutationObserver(() => {
+    const url = location.href;
+
+    if (url !== lastUrl) {
+        lastUrl = url;
+
+        CHAT_REPLACER_9000();
+    }
+}).observe(document, {subtree: true, childList: true});
+
+// update the chat src on youtube when message is received from background.js
+// chrome.runtime.onMessage.addListener(
+//     function(request, sender, sendResponse) {
+//         if (request.message == "updateSrc") {
+//             if (window.location.href.indexOf('youtube.com/watch') > -1) {
+//                 updateYoutubeSrc()
+//                 sendResponse({message: "src updated for youtube"});
+//                 }
+//             } 
+//         }
+// );

--- a/DGG_Chat_For_Youtube/src/content.js
+++ b/DGG_Chat_For_Youtube/src/content.js
@@ -42,11 +42,26 @@ function loadDGGYT() {
 
 document.onreadystatechange = function() {
     if (document.readyState === 'complete') {
-        try{
+
+        try {
             if (window.location.href.indexOf('youtube.com') > -1) {
-                setTimeout(() => { loadDGGYT() }, 500);
+                ObserverYT = new MutationObserver((mutationList, ObserverYT) => {
+                    if ($("ytd-live-chat-frame").length && $("#chatframe").length) {
+                        loadDGGYT()
+                        ObserverYT.disconnect();
+                    }}
+                );
+                ObserverYT.observe($('ytd-app')[0], {childList: true, subtree: true});
             } else if (window.location.href.indexOf('twitch.tv') > -1) {
-                setTimeout(() => { loadDGGTW() }, 500);
+
+                observerTW = new MutationObserver((mutationList, observer) => {
+                    if ($(`div[class*=channel-root__right-column]`).length) {
+                        loadDGGTW();
+                        observerTW.disconnect();
+                    }}
+                );
+                // this works for the most part but can have funky AdBlock behavior, not sure why yet
+                observerTW.observe($(`div[class*=channel-root__right-column]`)[0], {childList: true, subtree: true});
             }
         } catch (e) {
             console.log(e);

--- a/DGG_Chat_For_Youtube/src/popup.js
+++ b/DGG_Chat_For_Youtube/src/popup.js
@@ -5,6 +5,36 @@ chrome.storage.sync.get(["checkbox"], async function(result) {
     } else { document.getElementById("checkbox").checked = false }
 });
 
+function loadDGGTW() {
+    twitch_chat = $(`div[class*=channel-root__right-column]`);
+    
+    console.log(
+        '%c[DGG] %cPEEPO POOFING TWITCH CHAT AWAY',
+        'color: #538CC6',
+        'color: #6F859A',
+    );
+    twitch_chat.empty();
+    // console.log("POOF")
+    url = "https://www.destiny.gg/embed/chat"
+    twitch_chat.prepend(`<div style="display:block; height: 100% !important; width: 100% !important;"><iframe id="chatframe" class="dggChat" style="height: 100% !important; width: 100% !important; display: block;" src="${url}"></iframe></div>`)
+}
+
+function loadDGGYT() {
+    dggChat = $("ytd-live-chat-frame")
+    console.log(
+        '%c[DGG] %cPEEPO POOFING YOUTUBE CHAT AWAY',
+        'color: #538CC6',
+        'color: #6F859A',
+    );
+    dggChat.empty()
+    dggChat.css({
+        "flex-direction": "row",
+        "-webkit-flex-direction": "row",
+    });
+    url = "https://www.destiny.gg/embed/chat"
+    dggChat.prepend(`<iframe id="chatframe" class="dggChat" style="flex: auto;" src="${url}"></iframe>`)
+}
+
 checkbox.addEventListener("change", async(e) => {
     if (e.target.checked) {
         chrome.storage.sync.set({ "checkbox": true });
@@ -13,66 +43,75 @@ checkbox.addEventListener("change", async(e) => {
         chrome.scripting.executeScript({
             target: { tabId: tab.id },
             function: async() => {
-                chrome.storage.sync.set({
-                    "src": $('#chatframe').attr('src'),
-                    function() { console.log("src is set to" + $('#chatframe').attr('src')) }
-                });
-                ytChat = $("ytd-live-chat-frame")
-                ytChat.empty()
-                ytChat.css({
-                    "flex-direction": "row",
-                    "-webkit-flex-direction": "row",
-                });
-                url = "https://www.destiny.gg/embed/chat"
-                ytChat.prepend(`<iframe id="chatframe" class="dggChat" style="flex: auto;" src="${url}"></iframe>`)
-    
-                twitch_chat = $(`div[class*=channel-root__right-column]`);
-                twitch_chat.empty();
-                console.log(
-                    '%c[DGG] %cPEEPO POOFING TWITCH CHAT AWAY',
-                    'color: #538CC6',
-                    'color: #6F859A',
-                );
-                twitch_chat.prepend(`<div style="display:block; height: 100% !important; width: 100% !important;"><iframe id="chatframe" class="dggChat" style="height: 100% !important; width: 100% !important; display: block;" src="${url}"></iframe></div>`)
-                
+                if (window.location.href.indexOf('youtube.com') > -1) {
+                    // set the youtube chat src of the src of the chatframe
+                    chrome.storage.sync.set({"youtubeChatSrc": "https://www.youtube.com/live_chat?v=" + window.location.href.substring(window.location.href.lastIndexOf('=') + 1)})
+                    
+                    // load the dgg chat
+                    loadDGGYT()
+                    
+                } 
+                else if (window.location.href.indexOf('twitch.tv') > -1) {
+
+                    // set the twitch chat src from the window url
+                    chrome.storage.sync.set({"twitchChatSrc": `https://www.twitch.tv/popout/${
+                        window.location.href.substring(
+                            window.location.href.lastIndexOf('/') + 1
+                            )
+                        }/chat?popout=`})
+
+                    // get the chatframe and empty it
+                    if ($(`div[class*=channel-root__right-column]`)) {
+                        loadDGGTW();
+                        if ($(`iframe[class*=dggChat]`).length){
+                            clearInterval(intervalId);
+                        }
+                    }
+                }
             }
         });
     } else if (!e.target.checked) {
         chrome.storage.sync.set({ "checkbox": false });
-        let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-        
-        let streamer = tab.url.substring(tab.url.lastIndexOf('/') + 1);
-        console.log(tab.url)
-        console.log(streamer)
-        twitchSrc = `https://www.twitch.tv/popout/${streamer}/chat?popout=`
-        chrome.storage.sync.set({
-            "twitchSrc": twitchSrc });
-        chrome.scripting.executeScript({
-            target: { tabId: tab.id },
-            function: async() => {
 
-                ytChat = $("ytd-live-chat-frame")
-                ytChat.empty()
-                ytChat.css({
-                    "flex-direction": "column",
-                    "-webkit-flex-direction": "column",
-                });
+        chrome.tabs.query({
+            active: true,
+            currentWindow: true
+        }, function(tabs) {
+            const tab = tabs[0];
 
-                chrome.storage.sync.get(["src"], function(result) {
-                    id = result.src
-                    ytChat.prepend(`<!--css-build:shady--><iframe frameborder="0" scrolling="no" id="chatframe" class="style-scope ytd-live-chat-frame" src="${id}"></iframe>
-                <dom-if class="style-scope ytd-live-chat-frame"><template is="dom-if"></template></dom-if>
-                <div id="show-hide-button" class="style-scope ytd-live-chat-frame"><ytd-toggle-button-renderer class="style-scope ytd-live-chat-frame" use-keyboard-focused="" system-icons="" is-paper-button="" button-renderer="true"><a class="yt-simple-endpoint style-scope ytd-toggle-button-renderer" tabindex="-1"><tp-yt-paper-button id="button" class="style-scope ytd-toggle-button-renderer" style-target="host" role="button" tabindex="0" animated="" elevation="0" aria-disabled="false"><!--css-build:shady--><yt-formatted-string id="text" class="style-scope ytd-toggle-button-renderer">Hide chat replay</yt-formatted-string></tp-yt-paper-button></a></ytd-toggle-button-renderer></div>`)
-                });
+            chrome.scripting.executeScript({
+                target: { tabId: tab.id },
+                function: async() => {
 
-                chrome.storage.sync.get("twitchSrc", function(src) {
-                    src = src.twitchSrc
-                    twitch_chat = $(`div[class*=channel-root__right-column]`);
-                    twitch_chat.empty();
-                    twitch_chat.prepend(`<div style="display:block; height: 100% !important; width: 100% !important;"><iframe style="display:block; height: 100% !important; width: 100% !important;" src="${src}"></iframe></div>`);
-                });
-            }
-        });
+                    console.log("UNPOOFING")
+                    if (window.location.href.indexOf('youtube.com') > -1) {
+
+                        chrome.storage.sync.get(["youtubeChatSrc"], function(result) {
+                            id = `${result.youtubeChatSrc}`
+                            ytChat = $("ytd-live-chat-frame")
+                            ytChat.empty()
+                            ytChat.css({
+                                "flex-direction": "column",
+                                "-webkit-flex-direction": "column",
+                            });
+                            ytChat.prepend(
+                                `<!--css-build:shady--><iframe frameborder="0" scrolling="no" id="chatframe" class="style-scope ytd-live-chat-frame" src="${id}"></iframe>
+                                <dom-if class="style-scope ytd-live-chat-frame"><template is="dom-if"></template></dom-if>
+                                <div id="show-hide-button" class="style-scope ytd-live-chat-frame"><ytd-toggle-button-renderer class="style-scope ytd-live-chat-frame" use-keyboard-focused="" system-icons="" is-paper-button="" button-renderer="true"><a class="yt-simple-endpoint style-scope ytd-toggle-button-renderer" tabindex="-1"><tp-yt-paper-button id="button" class="style-scope ytd-toggle-button-renderer" style-target="host" role="button" tabindex="0" animated="" elevation="0" aria-disabled="false"><!--css-build:shady--><yt-formatted-string id="text" class="style-scope ytd-toggle-button-renderer">Hide chat replay</yt-formatted-string></tp-yt-paper-button></a></ytd-toggle-button-renderer></div>`)
+                                });
+                    }
+
+                    else if (window.location.href.indexOf('twitch.tv') > -1) {
+                        chrome.storage.sync.get("twitchChatSrc", function(src) {
+                            src = src.twitchChatSrc
+                            twitch_chat = $(`div[class*=channel-root__right-column]`);
+                            twitch_chat.empty();
+                            twitch_chat.prepend(`<div style="display:block; height: 100% !important; width: 100% !important;"><iframe style="display:block; height: 100% !important; width: 100% !important;" src="${src}"></iframe></div>`);
+                        });
+                    }
+                }
+            });
+        });    
     }
 });
 


### PR DESCRIPTION
Fixes #6 by using mutation observers to detect DOM loading. It can have funky behavior with AdBlockers like UBlock and TTV, which may require occasional reloads to update the Twitch chat when quickly switching between channels, but it should be good enough for now. 